### PR TITLE
各種文言を日本語に修正及びログイン、ログアウト時の画面の振り分け

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Resend confirmation instructions</h2>
+<h2>確認メールの再送信画面</h2>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
+    <%= f.submit "確認メールを再送信する" %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Forgot your password?</h2>
+<h2>パスワードを忘れましたか？</h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
+    <%= f.submit "パスワード再登録のメール送信" %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<h2>アカウント編集 <%= current_user.username %>さん</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -18,11 +18,11 @@
   <% end %>
 
   <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.label :password %> <i>(変更しない場合は空白のままにして下さい)</i><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>
       <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <em><%= @minimum_password_length %>文字以上入力してください</em>
     <% end %>
   </div>
 
@@ -32,17 +32,17 @@
   </div>
 
   <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.label :current_password %> <i>(変更を確認するには、現在のパスワードが必要です)</i><br />
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit "パスワード更新" %>
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
+<h3>アカウントを削除する</h3>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+<p> <%= button_to "アカウント削除", registration_path(resource_name), data: { confirm: "本当に削除しますか?" }, method: :delete %></p>
 
 <%= link_to "Back", :back %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -27,7 +27,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Sign up" %>
+    <%= f.submit "アカウント登録" %>
   </div>
 <% end %>
 

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Resend unlock instructions</h2>
+<h2>ロック解除手順の再送信画面</h2>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend unlock instructions" %>
+    <%= f.submit "ロック解除手順を再送信" %>
   </div>
 <% end %>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -26,7 +26,11 @@
           <%= link_to 'アカウント編集', edit_user_registration_path, class: "nav-link active" %>
           </li>
         <li class="nav-item">
+        <% if user_signed_in? %>
             <%= link_to 'ログアウト', destroy_user_session_path, class: "nav-link active", method: :delete %>
+          <% else %>
+            <%= link_to 'ログイン', new_user_session_path,  class: "nav-link active" %>
+         <% end %>
         </li>
       </ul>
     </div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,14 +1,10 @@
-
 <div class="text-center p-4 mx-5">
-<h1>ようこそ</h1>
-<p>ビルメン共有アプリです！</p>
-<%= link_to "記事を投稿する", new_post_path %>
+ <h1>ようこそ</h1>
+ <p>ビルメン共有アプリです！</p>
+ <%= link_to "記事を投稿する", new_post_path %>
  <% if user_signed_in? %>
-    <strong><%= link_to current_user.username, pages_show_path %></strong>
-    <%= link_to 'アカウント変更', edit_user_registration_path %>
-    <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
+    <strong><%= link_to "マイページへ", pages_show_path %></strong>
   <% else %>
     <%= link_to 'アカウント登録', new_user_registration_path %>
-    <%= link_to 'ログイン', new_user_session_path %>
-<% end %>
+ <% end %>
 </div>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,2 +1,4 @@
 <h1>こんにちは、<%= current_user.username %>さん</h1>
 <p>ユーザー様用ページです。</p>
+<%= link_to "記事を投稿する", new_post_path %>
+ <%= link_to "投稿一覧に戻る", posts_path %>


### PR DESCRIPTION
### 概要
- 各種文言を日本語に修正及びログイン、ログアウト時の画面の振り分け
## 内容
- 英語表記の文言を日本語に修正
- `_header.html.erb`内のログイン、ログアウト時の表示変更
- トップページのログイン、ログアウト時の表示変更
- マイページの表示変更